### PR TITLE
Use `setInterval` for repeating tasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,12 @@
 				"@colors/colors": "^1.6.0",
 				"delphi-ai": "^2.0.0",
 				"discord.js": "^14.14.1",
-				"dotenv": "^16.4.3"
+				"dotenv": "^16.4.5"
 			},
 			"devDependencies": {
 				"@jstnmcbrd/eslint-config": "^1.0.0",
 				"eslint": "^8.56.0",
-				"typescript": "^5.3.3"
+				"typescript": "^5.4.4"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -1104,9 +1104,9 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "16.4.3",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.3.tgz",
-			"integrity": "sha512-II98GFrje5psQTSve0E7bnwMFybNLqT8Vu8JIFWRjsE3khyNUm/loZupuy5DVzG2IXf/ysxvrixYOQnM6mjD3A==",
+			"version": "16.4.5",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
 			"engines": {
 				"node": ">=12"
 			},
@@ -3269,9 +3269,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+			"version": "5.4.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
+			"integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
 		"@colors/colors": "^1.6.0",
 		"delphi-ai": "^2.0.0",
 		"discord.js": "^14.14.1",
-		"dotenv": "^16.4.3"
+		"dotenv": "^16.4.5"
 	},
 	"devDependencies": {
 		"@jstnmcbrd/eslint-config": "^1.0.0",
 		"eslint": "^8.56.0",
-		"typescript": "^5.3.3"
+		"typescript": "^5.4.4"
 	}
 }

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -1,7 +1,7 @@
 /**
  * This manager takes care of keeping the client user's activity regularly updated.
  *
- * This is necessary because after being set, the user's activity eventually expire.
+ * This is necessary because after being set, the user's activity eventually expires.
  * https://github.com/JstnMcBrd/discord-delphi/issues/33
  */
 
@@ -40,18 +40,21 @@ const activityOptions: ActivityOptions = {
  * @param client The current logged-in client
  */
 export function start(client: Client<true>): void {
-	info('Updating activity...');
+	function update() {
+		info('Updating activity...');
 
-	try {
-		setActivity(client);
-	}
-	catch (err) {
-		error(err);
+		try {
+			setActivity(client);
+		}
+		catch (err) {
+			error(err);
+		}
 	}
 
-	setTimeout(() => {
-		start(client);
-	}, activityUpdateFrequency * 1000);
+	// Do now
+	update();
+	// Then repeat
+	setInterval(update, activityUpdateFrequency * 1000);
 }
 
 /**

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -2,6 +2,7 @@
  * This manager takes care of keeping the client user's activity regularly updated.
  *
  * This is necessary because after being set, the user's activity eventually expire.
+ * https://github.com/JstnMcBrd/discord-delphi/issues/33
  */
 
 import { ActivityType } from 'discord.js';
@@ -21,7 +22,7 @@ const activityOptions: ActivityOptions = {
 
 /**
  * // FIXME wait until Discord supports custom statuses for bots.
- * https://github.com/discord/discord-api-docs/issues/1160#issuecomment-546549516
+ * https://github.com/JstnMcBrd/discord-delphi/issues/5
  */
 // const activityOptions: ActivityOptions = {
 // 	name: 'Custom Status',
@@ -68,6 +69,7 @@ function setActivity(client: Client<true>): void {
 		|| activity.name !== activityOptions.name
 		|| activity.type !== activityOptions.type
 		|| activity.url !== activityOptions.url) {
+	// https://github.com/JstnMcBrd/discord-delphi/issues/3
 		throw new Error('User presence did not update correctly.');
 	}
 }

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -60,16 +60,12 @@ export function start(client: Client<true>): void {
  * @throws If the activity does not update correctly
  */
 function setActivity(client: Client<true>): void {
-	const { activities } = client.user.setActivity(activityOptions);
-	const activity = activities.at(0);
+	const updatedPresence = client.user.setActivity(activityOptions);
 
 	// Double check to see if it worked
 	// FIXME this currently always returns true, but discord.js doesn't have a better way to check
-	if (!activity
-		|| activity.name !== activityOptions.name
-		|| activity.type !== activityOptions.type
-		|| activity.url !== activityOptions.url) {
 	// https://github.com/JstnMcBrd/discord-delphi/issues/3
+	if (!client.user.presence.equals(updatedPresence)) {
 		throw new Error('User presence did not update correctly.');
 	}
 }

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -11,7 +11,7 @@ import type { ActivityOptions, Client } from 'discord.js';
 import { error, info } from './logger.js';
 
 /** How often to update the activity (in seconds). */
-const activityUpdateFrequency = 5 * 60;
+const activityUpdateFrequency = 1 * 60 * 60;
 
 /** The activity the bot should use. */
 const activityOptions: ActivityOptions = {


### PR DESCRIPTION
### Changed

- Issue references to directly reference issues in this repository, instead of external repositories
- Activity update to occur every hour instead of every 5 minutes
- User presence comparison to be cleaner (still broken though)
- All repeating tasks to use `setInterval` instead of `setTimeout`
- Dependencies to latest minor versions

### Fixed

- Spelling