### PR TITLE
Replace `dotenv` with Node built-in `.env` file support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
 				"@jstnmcbrd/eslint-config": "^1.0.0",
 				"eslint": "^8.57.0",
 				"typescript": "^5.5.4"
+			},
+			"engines": {
+				"node": ">=20.6.0"
 			}
 		},
 		"node_modules/@colors/colors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
 			"dependencies": {
 				"@colors/colors": "^1.6.0",
 				"delphi-ai": "^2.0.1",
-				"discord.js": "^14.15.3",
-				"dotenv": "^16.4.5"
+				"discord.js": "^14.15.3"
 			},
 			"devDependencies": {
 				"@jstnmcbrd/eslint-config": "^1.0.0",
@@ -1286,18 +1285,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/dotenv": {
-			"version": "16.4.5",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/es-abstract": {

--- a/package.json
+++ b/package.json
@@ -22,16 +22,15 @@
 	"type": "module",
 	"scripts": {
 		"build": "tsc",
-		"commands": "node dist/deployCommands.js",
+		"commands": "node --env-file=.env dist/deployCommands.js",
 		"lint": "eslint .",
-		"start": "node dist/main.js",
+		"start": "node --env-file=.env dist/main.js",
 		"test": "echo \"No tests\""
 	},
 	"dependencies": {
 		"@colors/colors": "^1.6.0",
 		"delphi-ai": "^2.0.1",
-		"discord.js": "^14.15.3",
-		"dotenv": "^16.4.5"
+		"discord.js": "^14.15.3"
 	},
 	"devDependencies": {
 		"@jstnmcbrd/eslint-config": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
 		"@jstnmcbrd/eslint-config": "^1.0.0",
 		"eslint": "^8.57.0",
 		"typescript": "^5.5.4"
+	},
+	"engines": {
+		"node": ">=20.6.0"
 	}
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -22,7 +22,7 @@ addCommandHandler(invite);
  */
 function addCommandHandler(command: CommandHandler): void {
 	if (commandHandlers.has(command.name)) {
-		throw new TypeError(`Failed to add command '${command.name}' because a command with that name already exists.`);
+		throw new Error(`Failed to add command '${command.name}' because a command with that name already exists.`);
 	}
 
 	commandHandlers.set(command.name, command);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -21,11 +21,12 @@ addCommandHandler(invite);
  * @throws If there is already a handler with the same command name in the list
  */
 function addCommandHandler(command: CommandHandler): void {
-	if (commandHandlers.has(command.name)) {
-		throw new Error(`Failed to add command '${command.name}' because a command with that name already exists.`);
-	}
+	const name = command.name;
 
-	commandHandlers.set(command.name, command);
+	if (commandHandlers.has(name)) {
+		throw new Error(`Failed to add command '${name}' because a command with that name already exists.`);
+	}
+	commandHandlers.set(name, command);
 }
 
 /**

--- a/src/deployCommands.ts
+++ b/src/deployCommands.ts
@@ -9,16 +9,6 @@ import { getCommandHandlers } from './commands/index.js';
 import { getToken } from './memory/env.js';
 import { debug, error, info } from './logger.js';
 
-async function deployCommands(c: Client<true>): Promise<void> {
-	debug(`\tUser: ${c.user.username} (${c.user.id})`);
-
-	info('Deploying commands...');
-	await c.application.commands.set(commandJSONs);
-
-	info('Logging out...');
-	await c.destroy();
-}
-
 // Get the JSON data of the commands
 info('Retrieving commands...');
 const commandHandlers = Array.from(getCommandHandlers().values());
@@ -30,7 +20,15 @@ commandHandlers.forEach((command) => {
 // Setup client
 const client = new Client<false>({ intents: [] });
 client.on('error', error);
-client.once('ready', c => void deployCommands(c));
+client.once('ready', client => void (async function () {
+	debug(`\tUser: ${client.user.username} (${client.user.id})`);
+
+	info('Deploying commands...');
+	await client.application.commands.set(commandJSONs);
+
+	info('Logging out...');
+	await client.destroy();
+})());
 
 // Login
 const token = getToken();

--- a/src/deployCommands.ts
+++ b/src/deployCommands.ts
@@ -28,7 +28,7 @@ commandHandlers.forEach((command) => {
 });
 
 // Setup client
-const client = new Client({ intents: [] });
+const client = new Client<false>({ intents: [] });
 client.on('error', error);
 client.once('ready', c => void deployCommands(c));
 

--- a/src/deployCommands.ts
+++ b/src/deployCommands.ts
@@ -6,7 +6,7 @@
 import { Client } from 'discord.js';
 
 import { getCommandHandlers } from './commands/index.js';
-import { getToken, load as loadEnv } from './memory/env.js';
+import { getToken } from './memory/env.js';
 import { debug, error, info } from './logger.js';
 
 async function deployCommands(c: Client<true>): Promise<void> {
@@ -18,10 +18,6 @@ async function deployCommands(c: Client<true>): Promise<void> {
 	info('Logging out...');
 	await c.destroy();
 }
-
-// Load environment variables
-loadEnv();
-const token = getToken();
 
 // Get the JSON data of the commands
 info('Retrieving commands...');
@@ -37,5 +33,6 @@ client.on('error', error);
 client.once('ready', c => void deployCommands(c));
 
 // Login
+const token = getToken();
 info('Logging in...');
 await client.login(token);

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -24,7 +24,7 @@ function addEventHandler(event: EventHandler): void {
 	const name = event.name;
 
 	if (eventHandlers.has(name)) {
-		throw new TypeError(`Failed to add event handler '${name}' because an event with that name already exists.`);
+		throw new Error(`Failed to add event handler '${name}' because an event with that name already exists.`);
 	}
 	eventHandlers.set(name, event);
 }

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,4 +1,4 @@
-import type { Client } from 'discord.js';
+import type { Client, ClientEvents } from 'discord.js';
 
 import { error } from './error.js';
 import type { EventHandler } from './EventHandler.js';
@@ -7,7 +7,7 @@ import { messageCreate } from './messageCreate.js';
 import { ready } from './ready.js';
 
 /** The list of all event handlers. */
-const eventHandlers = new Map<string, EventHandler>();
+const eventHandlers = new Map<keyof ClientEvents, EventHandler>();
 
 addEventHandler(error);
 addEventHandler(interactionCreate);

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,15 +4,11 @@ import { ActivityType, Client, Partials, GatewayIntentBits } from 'discord.js';
 import type { ActivityOptions } from 'discord.js';
 
 import { registerEventHandlers } from './events/index.js';
-import { getToken, load as loadEnv } from './memory/env.js';
+import { getToken } from './memory/env.js';
 import { info } from './logger.js';
 
 info('discord-delphi');
 info();
-
-// Load environment variables
-loadEnv();
-const token = getToken();
 
 /** The activity the bot should use. */
 const activityOptions: ActivityOptions = {
@@ -57,5 +53,6 @@ const client = new Client({
 registerEventHandlers(client);
 
 // Login
+const token = getToken();
 info('Logging in...');
 await client.login(token);

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ const activityOptions: ActivityOptions = {
 };
 
 // Setup client
-const client = new Client({
+const client = new Client<false>({
 	// Setting the activity in the client constructor resolves the disappearing issue
 	// https://github.com/JstnMcBrd/discord-delphi/issues/33
 	presence: {

--- a/src/memory/env.ts
+++ b/src/memory/env.ts
@@ -2,50 +2,26 @@
  * Takes care of loading and returning environment variables from the `.env` file.
 */
 
-import { config } from 'dotenv';
-
-/**
- * The expected format of the `.env` file.
- * See an example in [.env-example](../../.env-example).
- */
-interface Environment {
-	TOKEN: string;
-}
-
-/** The local copy of the environment. */
-let environment: Environment;
-
-/**
- * Loads the environment from the `.env` file and validates the formatting.
- *
- * Should be called before trying to access the environment.
- *
- * @throws If the `.env` file is improperly formatted
- */
-export function load(): void {
-	const processEnv = {};
-	config({ processEnv });
-
-	if (!isValidEnvironment(processEnv)) {
-		throw new Error('The .env file at is missing the required variables.');
-	}
-
-	environment = processEnv;
-}
-
-/**
- * @returns Whether the given environment has all of the required variables.
- */
-function isValidEnvironment(env: unknown): env is Environment {
-	return env instanceof Object
-		&& Object.prototype.hasOwnProperty.call(env, 'TOKEN');
-}
+import { env } from 'node:process';
 
 /**
  * WARNING: do not store or log your token in any publicly available place, or your bot will get hacked!
  *
- * @returns The Discord token necessary to authenticate the client
+ * @returns The Discord token necessary to authenticate the client, retrieved from the local .env file
+ * @throws If the .env file does not contain a token
  */
 export function getToken(): string {
-	return environment.TOKEN;
+	return getRequiredEnvVar('TOKEN');
+}
+
+/**
+ * Retrieves the requested environment variable from the local .env file
+ * @throws If the requested environment variable is not included, not defined, or empty
+ */
+function getRequiredEnvVar(name: string): string {
+	const value = env[name];
+	if (!value) {
+		throw new TypeError(`Missing required '${name}' environment variable.`);
+	}
+	return value;
 }


### PR DESCRIPTION
### Added

- `.env` file argument to Node scripts
  - https://nodejs.org/en/blog/release/v20.6.0#built-in-env-file-support
- Minimum Node requirement of v20.6.0

### Changed

- Error subtypes to better fit the meaning
- `.env` wrapper script to use `process.env` instead of `dotenv`
- Client initialization to explicitly set ready generic to `<false>`
- Deploy commands script to be more concise