### PR TITLE
Use types for Node 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 			},
 			"devDependencies": {
 				"@jstnmcbrd/eslint-config": "^1.0.0",
+				"@types/node": "^22.10.5",
 				"eslint": "^8.57.1",
 				"typescript": "^5.7.2"
 			},
@@ -527,12 +528,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.14.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
-			"integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
+			"version": "22.10.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+			"integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~5.26.4"
+				"undici-types": "~6.20.0"
 			}
 		},
 		"node_modules/@types/semver": {
@@ -3760,9 +3761,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
 			"license": "MIT"
 		},
 		"node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 	},
 	"devDependencies": {
 		"@jstnmcbrd/eslint-config": "^1.0.0",
+		"@types/node": "^22.10.5",
 		"eslint": "^8.57.1",
 		"typescript": "^5.7.2"
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
 		"noUncheckedSideEffectImports": true,
 		"verbatimModuleSyntax": true,
 		"isolatedModules": true,
-		// FIXME https://github.com/discordjs/discord.js/issues/10358
+		// FIXME https://github.com/discordjs/discord.js/issues/10577
 		"skipLibCheck": true
 	},
 }


### PR DESCRIPTION
Despite using node libraries, I didn't have `@types/node` listed as a dependency - instead, I was relying on a version installed as subdependency, which was using `v20` when I run node `v22`.

---

### Changed

- Pinned `@types/node` version to match version in `nvmrc`
- `discord.js` type issue link

### Fixed

- Type errors from using `@types/node@20`