### PR TITLE
Use `clientReady` event instead of `ready`

### DIFF
--- a/src/events/clientReady.ts
+++ b/src/events/clientReady.ts
@@ -3,7 +3,7 @@ import { debug } from '../logger.js';
 import { syncCommands } from '../commands/index.js';
 
 /** Called once the client successfully logs in. */
-export const ready = new EventHandler('ready')
+export const clientReady = new EventHandler('clientReady')
 	.setOnce(true)
 	.setExecution(async (client) => {
 		debug(`\tUser: ${client.user.username} (${client.user.id})`);

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,18 +1,18 @@
 import type { Client, ClientEvents } from 'discord.js';
 
+import { clientReady } from './clientReady.js';
 import { error } from './error.js';
 import type { EventHandler } from './EventHandler.js';
 import { interactionCreate } from './interactionCreate.js';
 import { messageCreate } from './messageCreate.js';
-import { ready } from './ready.js';
 
 /** The list of all event handlers. */
 const eventHandlers = new Map<keyof ClientEvents, EventHandler>();
 
+addEventHandler(clientReady);
 addEventHandler(error);
 addEventHandler(interactionCreate);
 addEventHandler(messageCreate);
-addEventHandler(ready);
 
 /**
  * Add the given event handler to the list of event handlers.


### PR DESCRIPTION
### Changed

- Replaced `ready` event with `clientReady` (`ready` was deprecated in `discord.js@14.20.0`)