### PR TITLE
Fix `devEngines` requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	"devEngines": {
 		"runtime": {
 			"name": "node",
-			"version": ">=22.18.0"
+			"version": "^22.18.0 || >=24"
 		}
 	}
 }


### PR DESCRIPTION
Not all versions of Node 23 support native TypeScript