### PR TITLE
Clean up README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exit with error code if commands are out-of-sync ([#36](https://github.com/JstnMcBrd/discord-delphi/pull/36))
 - Set user activity on Client initialization to fix user activity disappearing ([#36](https://github.com/JstnMcBrd/discord-delphi/pull/36))
 - Use `Object.assign` instead of `Reflect.set` ([#40](https://github.com/JstnMcBrd/discord-delphi/pull/40))
-- Use native Node `.env` file support instead of `dotenv` ([#42](https://github.com/JstnMcBrd/discord-delphi/pull/42))
-- Add Node version requirement of `>=20.6.0` ([#42](https://github.com/JstnMcBrd/discord-delphi/pull/42))
+- Use native Node.js `.env` file support instead of `dotenv` ([#42](https://github.com/JstnMcBrd/discord-delphi/pull/42))
+- Add Node.js version requirement of `>=20.6.0` ([#42](https://github.com/JstnMcBrd/discord-delphi/pull/42))
 - Change error subtypes to better fit their intended meaning ([#42](https://github.com/JstnMcBrd/discord-delphi/pull/42))
 - Support `PartialGroupDMChannel` ([#55](https://github.com/JstnMcBrd/discord-delphi/pull/55))
-- Update runtime to Node 24 ([#58](https://github.com/JstnMcBrd/discord-delphi/pull/58), [#121](https://github.com/JstnMcBrd/discord-delphi/pull/121))
+- Update runtime to Node.js 24 ([#58](https://github.com/JstnMcBrd/discord-delphi/pull/58), [#121](https://github.com/JstnMcBrd/discord-delphi/pull/121))
 - Use `clientReady` event instead of `ready` ([#107](https://github.com/JstnMcBrd/discord-delphi/pull/107))
 - Use for-of loops instead of forEach method ([#131](https://github.com/JstnMcBrd/discord-delphi/pull/131))
 - Format error embeds as code blocks ([#139](https://github.com/JstnMcBrd/discord-delphi/pull/139))
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update runtime to Node 20 ([#23](https://github.com/JstnMcBrd/discord-delphi/pull/23))
+- Update runtime to Node.js 20 ([#23](https://github.com/JstnMcBrd/discord-delphi/pull/23))
 - Reformat code with new `eslint` config ([#24](https://github.com/JstnMcBrd/discord-delphi/pull/24), [#25](https://github.com/JstnMcBrd/discord-delphi/pull/25), [#27](https://github.com/JstnMcBrd/discord-delphi/pull/27))
 
 ### Added
@@ -93,10 +93,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make all embeds use a default color palette ([#10](https://github.com/JstnMcBrd/discord-delphi/pull/10))
 - Use command mentions for all embeds that mention commands ([#10](https://github.com/JstnMcBrd/discord-delphi/pull/10))
 - Use environment variables for sensitive tokens instead of `config.json` ([#10](https://github.com/JstnMcBrd/discord-delphi/pull/10))
-- Refactor `package.json` to follow best practices for a NodeJS project ([#10](https://github.com/JstnMcBrd/discord-delphi/pull/10))
+- Refactor `package.json` to follow best practices for a Node.js project ([#10](https://github.com/JstnMcBrd/discord-delphi/pull/10))
 - Update documentation in README for complete refactor ([#10](https://github.com/JstnMcBrd/discord-delphi/pull/10))
 - Improve README to be more concise ([#10](https://github.com/JstnMcBrd/discord-delphi/pull/10))
-- Replace `node-fetch` dependency with native NodeJS `fetch` method ([#10](https://github.com/JstnMcBrd/discord-delphi/pull/10))
+- Replace `node-fetch` dependency with native Node.js `fetch` method ([#10](https://github.com/JstnMcBrd/discord-delphi/pull/10))
 - Include the year Delphi was released in the `/help` embed ([#10](https://github.com/JstnMcBrd/discord-delphi/pull/10))
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use for-of loops instead of forEach method ([#131](https://github.com/JstnMcBrd/discord-delphi/pull/131))
 - Format error embeds as code blocks ([#139](https://github.com/JstnMcBrd/discord-delphi/pull/139))
 - Use `Events` enum for event handler names ([#145](https://github.com/JstnMcBrd/discord-delphi/pull/145))
+- Clean up README ([#164](https://github.com/JstnMcBrd/discord-delphi/pull/164))
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## About
 
-`discord-delphi` is a [Discord](https://discord.com/) bot that uses the [Delphi AI](https://delphi.allenai.org/) to provide moral and ethical judgements. Through the bot, users can have their messages judged for morality. It is developed in [TypeScript](https://www.typescriptlang.org/) and relies on the [Node](https://nodejs.org/) module of [delphi-ai](https://www.npmjs.com/package/delphi-ai).
+`discord-delphi` is a [Discord](https://discord.com/) bot that uses the [Delphi AI](https://delphi.allenai.org/) to provide moral and ethical judgements. Through the bot, users can have their messages judged for morality. It is developed in [TypeScript](https://www.typescriptlang.org/), runs with [Node.js](https://nodejs.org/). and relies on the npm module of [delphi-ai](https://www.npmjs.com/package/delphi-ai).
 
 The project was started in October 2021 using the codebase of the [discord-cleverbot](https://github.com/JstnMcBrd/discord-cleverbot) project.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For legal reasons, if you choose to contribute to this project, you agree to giv
 
 ### Setting up the code
 
-- You will need an environment with [Node](https://nodejs.org/en/download) installed (or use the Dev Container - see the [Development](#development) section below).
+- You will need an environment with [Node.js](https://nodejs.org/en/download) installed.
 - Run `git clone https://github.com/JstnMcBrd/discord-delphi.git` to clone the repo.
 - Create a new file called `.env` and add your access token, using [`.env.example`](./.env.example) as an example.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # discord-delphi
 
 [![API Status](https://img.shields.io/github/actions/workflow/status/JstnMcBrd/delphi-ai/api-status.yml?logo=github&label=API%20Status)](https://github.com/JstnMcBrd/delphi-ai/actions/workflows/api-status.yml)
-[![CI](https://img.shields.io/github/actions/workflow/status/JstnMcBrd/discord-delphi/ci.yml?logo=github&label=CI)](https://github.com/JstnMcBrd/discord-delphi/actions/workflows/ci.yml)
 
 > <img alt="Warning" src="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/main/blockquotes/badge/dark-theme/error.svg"> 
 >


### PR DESCRIPTION
- Use correct name of Node.js
- Remove outdated mention of devcontainer
- Remove CI badge (redundant - CI status is already visible)