### PR TITLE
Run TypeScript natively with Node.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-# Lints, builds, and tests the project whenever a pull request is opened or merged
+# Lints, type-checks, and tests the project whenever a pull request is opened or merged
 
 on:
   pull_request:
@@ -35,8 +35,8 @@ jobs:
       - name: Lint
         run: npm run lint
 
-  build:
-    name: Build
+  type-check:
+    name: Type-check
 
     runs-on: ubuntu-latest
 
@@ -56,8 +56,8 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
 
-      - name: Build
-        run: npm run build
+      - name: Type-check
+        run: npm run type-check
 
   test:
     name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
-dist
 .env
 todo

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
 			"skipFiles": [
 				"<node_internals>/**"
 			],
-			"program": "${workspaceFolder}/dist/main.js",
+			"program": "${workspaceFolder}/src/main.ts",
 			"envFile": "${workspaceFolder}/.env",
 		},
 	],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove user activity manager that set user activity on a regular schedule ([#36](https://github.com/JstnMcBrd/discord-delphi/pull/36))
+- Remove build step ([#165](https://github.com/JstnMcBrd/discord-delphi/pull/165))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Format error embeds as code blocks ([#139](https://github.com/JstnMcBrd/discord-delphi/pull/139))
 - Use `Events` enum for event handler names ([#145](https://github.com/JstnMcBrd/discord-delphi/pull/145))
 - Clean up README ([#164](https://github.com/JstnMcBrd/discord-delphi/pull/164))
+- Run TypeScript natively with Node.js ([#165](https://github.com/JstnMcBrd/discord-delphi/pull/165))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set user activity on Client initialization to fix user activity disappearing ([#36](https://github.com/JstnMcBrd/discord-delphi/pull/36))
 - Use `Object.assign` instead of `Reflect.set` ([#40](https://github.com/JstnMcBrd/discord-delphi/pull/40))
 - Use native Node.js `.env` file support instead of `dotenv` ([#42](https://github.com/JstnMcBrd/discord-delphi/pull/42))
-- Add Node.js version requirement of `>=20.6.0` ([#42](https://github.com/JstnMcBrd/discord-delphi/pull/42))
+- Add Node.js version requirement of `^22.18.0 || >=24` ([#42](https://github.com/JstnMcBrd/discord-delphi/pull/42), [#165](https://github.com/JstnMcBrd/discord-delphi/pull/165))
 - Change error subtypes to better fit their intended meaning ([#42](https://github.com/JstnMcBrd/discord-delphi/pull/42))
 - Support `PartialGroupDMChannel` ([#55](https://github.com/JstnMcBrd/discord-delphi/pull/55))
 - Update runtime to Node.js 24 ([#58](https://github.com/JstnMcBrd/discord-delphi/pull/58), [#121](https://github.com/JstnMcBrd/discord-delphi/pull/121))

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## About
 
-`discord-delphi` is a [Discord](https://discord.com/) bot that uses the [Delphi AI](https://delphi.allenai.org/) to provide moral and ethical judgements. Through the bot, users can have their messages judged for morality. It is developed in [TypeScript](https://www.typescriptlang.org/), runs with [Node.js](https://nodejs.org/). and relies on the npm module of [delphi-ai](https://www.npmjs.com/package/delphi-ai).
+`discord-delphi` is a [Discord](https://discord.com/) bot that uses the [Delphi AI](https://delphi.allenai.org/) to provide moral and ethical judgements. Through the bot, users can have their messages judged for morality. It is developed in [TypeScript](https://www.typescriptlang.org/), runs with [Node.js](https://nodejs.org/), and relies on the npm module of [delphi-ai](https://www.npmjs.com/package/delphi-ai).
 
 The project was started in October 2021 using the codebase of the [discord-cleverbot](https://github.com/JstnMcBrd/discord-cleverbot) project.
 
@@ -35,7 +35,6 @@ For legal reasons, if you choose to contribute to this project, you agree to giv
 ### Running the code
 
 - In the top directory, run `npm install` to download all necessary packages.
-- Run `npm run build` to build the project.
 - Run `npm run commands` to register slash commands with Discord.
 - Run `npm start` to start the bot.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"typescript": "^5.9.3"
 			},
 			"engines": {
-				"node": ">=20.6.0"
+				"node": "^22.18.0 || >=24"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"commands": "node --env-file=.env dist/deployCommands.js",
 		"lint": "eslint --flag unstable_native_nodejs_ts_config",
 		"start": "node --env-file=.env dist/main.js",
+		"type-check": "tsc --noEmit",
 		"test": "echo \"No tests\""
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,12 +39,6 @@
 		"typescript": "^5.9.3"
 	},
 	"engines": {
-		"node": ">=20.6.0"
-	},
-	"devEngines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.18.0 || >=24"
-		}
+		"node": "^22.18.0 || >=24"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
 	"author": "Justin McBride",
 	"type": "module",
 	"scripts": {
-		"build": "tsc -p tsconfig.build.json",
 		"commands": "node --env-file=.env dist/deployCommands.js",
 		"lint": "eslint --flag unstable_native_nodejs_ts_config",
 		"start": "node --env-file=.env dist/main.js",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
 	"author": "Justin McBride",
 	"type": "module",
 	"scripts": {
-		"commands": "node --env-file=.env dist/deployCommands.js",
+		"commands": "node --env-file=.env src/deployCommands.ts",
+		"start": "node --env-file=.env src/main.ts",
 		"lint": "eslint --flag unstable_native_nodejs_ts_config",
-		"start": "node --env-file=.env dist/main.js",
 		"type-check": "tsc --noEmit",
 		"test": "echo \"No tests\""
 	},

--- a/src/commands/CommandHandler.ts
+++ b/src/commands/CommandHandler.ts
@@ -1,8 +1,8 @@
 import { chatInputApplicationCommandMention, inlineCode, SlashCommandBuilder } from 'discord.js';
 import type { ChatInputCommandInteraction, Snowflake } from 'discord.js';
 
-import { replyWithError } from '../utils/replyWithError.js';
-import { error } from '../logger.js';
+import { replyWithError } from '../utils/replyWithError.ts';
+import { error } from '../logger.ts';
 
 /**
  * An add-on to the `SlashCommandBuilder` class from discord.js that adds a command execution

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,9 +1,9 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, userMention } from 'discord.js';
 import type { ClientUser } from 'discord.js';
 
-import { CommandHandler } from './CommandHandler.js';
-import { invite } from './invite.js';
-import { embedColors, githubURL, lastUpdated, version } from '../parameters.js';
+import { CommandHandler } from './CommandHandler.ts';
+import { invite } from './invite.ts';
+import { embedColors, githubURL, lastUpdated, version } from '../parameters.ts';
 
 /** A command that gives the user a simple guide about the bot. */
 export const help = new CommandHandler()

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,11 +2,11 @@ import { exit } from 'node:process';
 
 import type { Client } from 'discord.js';
 
-import type { CommandHandler } from './CommandHandler.js';
-import { help } from './help.js';
-import { invite } from './invite.js';
-import { error } from '../logger.js';
-import { areCommandsInSync } from '../utils/areCommandsInSync.js';
+import type { CommandHandler } from './CommandHandler.ts';
+import { help } from './help.ts';
+import { invite } from './invite.ts';
+import { error } from '../logger.ts';
+import { areCommandsInSync } from '../utils/areCommandsInSync.ts';
 
 /** The list of all command handlers. */
 const commandHandlers = new Map<string, CommandHandler>();

--- a/src/commands/invite.ts
+++ b/src/commands/invite.ts
@@ -1,8 +1,8 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } from 'discord.js';
 import type { ClientUser } from 'discord.js';
 
-import { CommandHandler } from './CommandHandler.js';
-import { embedColors } from '../parameters.js';
+import { CommandHandler } from './CommandHandler.ts';
+import { embedColors } from '../parameters.ts';
 
 /** A command that allows the user to invite the bot to a new server. */
 export const invite = new CommandHandler()

--- a/src/deployCommands.ts
+++ b/src/deployCommands.ts
@@ -5,9 +5,9 @@
 
 import { Client, Events } from 'discord.js';
 
-import { getCommandHandlers } from './commands/index.js';
-import { getToken } from './memory/env.js';
-import { debug, error, info } from './logger.js';
+import { getCommandHandlers } from './commands/index.ts';
+import { getToken } from './memory/env.ts';
+import { debug, error, info } from './logger.ts';
 
 // Get the JSON data of the commands
 info('Retrieving commands...');

--- a/src/events/EventHandler.ts
+++ b/src/events/EventHandler.ts
@@ -1,6 +1,6 @@
 import type { ClientEvents } from 'discord.js';
 
-import { error } from '../logger.js';
+import { error } from '../logger.ts';
 
 /**
  * Mimics the `SlashCommandBuilder` class from discord.js and the `CommandHandler` class to

--- a/src/events/clientReady.ts
+++ b/src/events/clientReady.ts
@@ -1,8 +1,8 @@
 import { Events } from 'discord.js';
 
-import { EventHandler } from './EventHandler.js';
-import { debug } from '../logger.js';
-import { syncCommands } from '../commands/index.js';
+import { EventHandler } from './EventHandler.ts';
+import { debug } from '../logger.ts';
+import { syncCommands } from '../commands/index.ts';
 
 /** Called once the client successfully logs in. */
 export const clientReady = new EventHandler(Events.ClientReady)

--- a/src/events/error.ts
+++ b/src/events/error.ts
@@ -1,7 +1,7 @@
 import { Events } from 'discord.js';
 
-import { EventHandler } from './EventHandler.js';
-import { error as errorLog } from '../logger.js';
+import { EventHandler } from './EventHandler.ts';
+import { error as errorLog } from '../logger.ts';
 
 /** Called whenever the client encounters an error. */
 export const error = new EventHandler(Events.Error)

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,10 +1,10 @@
 import type { Client, ClientEvents } from 'discord.js';
 
-import { clientReady } from './clientReady.js';
-import { error } from './error.js';
-import type { EventHandler } from './EventHandler.js';
-import { interactionCreate } from './interactionCreate.js';
-import { messageCreate } from './messageCreate.js';
+import { clientReady } from './clientReady.ts';
+import { error } from './error.ts';
+import type { EventHandler } from './EventHandler.ts';
+import { interactionCreate } from './interactionCreate.ts';
+import { messageCreate } from './messageCreate.ts';
 
 /** The list of all event handlers. */
 const eventHandlers = new Map<keyof ClientEvents, EventHandler>();

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,10 +1,10 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
 import { Events, PartialGroupDMChannel } from 'discord.js';
 
-import type { CommandHandler } from '../commands/CommandHandler.js';
-import { EventHandler } from './EventHandler.js';
-import { getCommandHandler } from '../commands/index.js';
-import { debug, info } from '../logger.js';
+import type { CommandHandler } from '../commands/CommandHandler.ts';
+import { EventHandler } from './EventHandler.ts';
+import { getCommandHandler } from '../commands/index.ts';
+import { debug, info } from '../logger.ts';
 
 /** Called whenever the client receives an interaction (usually a slash command). */
 export const interactionCreate = new EventHandler(Events.InteractionCreate)

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -2,13 +2,13 @@ import delphi from 'delphi-ai';
 import type { Message, TextBasedChannel } from 'discord.js';
 import { Events, PartialGroupDMChannel } from 'discord.js';
 
-import { EventHandler } from './EventHandler.js';
-import { formatPrompt } from '../utils/formatPrompt.js';
-import { doesMentionSelf, isFromSelf, isEmpty } from '../utils/messageAnalysis.js';
-import { replyWithError } from '../utils/replyWithError.js';
-import { sleep } from '../utils/sleep.js';
-import { typingSpeed } from '../parameters.js';
-import { debug, error, info } from '../logger.js';
+import { EventHandler } from './EventHandler.ts';
+import { formatPrompt } from '../utils/formatPrompt.ts';
+import { doesMentionSelf, isFromSelf, isEmpty } from '../utils/messageAnalysis.ts';
+import { replyWithError } from '../utils/replyWithError.ts';
+import { sleep } from '../utils/sleep.ts';
+import { typingSpeed } from '../parameters.ts';
+import { debug, error, info } from '../logger.ts';
 
 /** Called whenever the client observes a new message. */
 export const messageCreate = new EventHandler(Events.MessageCreate)

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,9 @@
 import { ActivityType, Client, Partials, GatewayIntentBits } from 'discord.js';
 import type { ActivityOptions } from 'discord.js';
 
-import { registerEventHandlers } from './events/index.js';
-import { getToken } from './memory/env.js';
-import { info } from './logger.js';
+import { registerEventHandlers } from './events/index.ts';
+import { getToken } from './memory/env.ts';
+import { info } from './logger.ts';
 
 info('discord-delphi');
 info();

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -1,6 +1,6 @@
 import { Colors } from 'discord.js';
 
-import { getVersion } from './utils/getVersion.js';
+import { getVersion } from './utils/getVersion.ts';
 
 /** The version number of this project. */
 export const version = getVersion();

--- a/src/utils/areCommandsInSync.ts
+++ b/src/utils/areCommandsInSync.ts
@@ -2,7 +2,7 @@ import { isDeepStrictEqual } from 'node:util';
 
 import type { ApplicationCommand } from 'discord.js';
 
-import { CommandHandler } from '../commands/CommandHandler.js';
+import { CommandHandler } from '../commands/CommandHandler.ts';
 
 /**
  * @param deployedCommands A list of commands currently deployed, pulled from the Discord API

--- a/src/utils/replyWithError.ts
+++ b/src/utils/replyWithError.ts
@@ -1,8 +1,8 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, codeBlock, EmbedBuilder } from 'discord.js';
 import type { ChatInputCommandInteraction, Message } from 'discord.js';
 
-import { embedColors, githubURL } from '../parameters.js';
-import { error } from '../logger.js';
+import { embedColors, githubURL } from '../parameters.ts';
+import { error } from '../logger.ts';
 
 /**
  * Replies to a Discord message or interaction with an error message.

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"include": ["src"],
-	"compilerOptions": {
-		"outDir": "dist",
-		"sourceMap": true,
-	},
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 	"compilerOptions": {
 		"target": "ESNext",
 		"module": "NodeNext",
+
 		"strict": true,
 		"noUncheckedIndexedAccess": true,
 		"exactOptionalPropertyTypes": true,
@@ -11,5 +12,7 @@
 		"noUncheckedSideEffectImports": true,
 		"verbatimModuleSyntax": true,
 		"isolatedModules": true,
+
+		"allowImportingTsExtensions": true,
 	},
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
 		"verbatimModuleSyntax": true,
 		"isolatedModules": true,
 
+		"noEmit": true,
 		"allowImportingTsExtensions": true,
 	},
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,6 @@
 
 		"noEmit": true,
 		"allowImportingTsExtensions": true,
+		"erasableSyntaxOnly": true,
 	},
 }


### PR DESCRIPTION
Node.js can run TypeScript natively in `^22.18.0 || >=24`.

- Increase Node.js version requirement to `^22.18.0 || >=24`
- Remove build step, replace with type-check step
- Add `noEmit` tsconfig option
- Rewrite internal imports from `.js` to `.ts` with `allowImportingTsExtensions`
- Point node to `src` files instead of `dist`
- Turn on `erasableSyntaxOnly` to enforce compatibility