### PR TITLE
Use ephemeral flag instead of deprecated response option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change error subtypes to better fit their intended meaning ([#42](https://github.com/JstnMcBrd/discord-delphi/pull/42))
 - Support `PartialGroupDMChannel` ([#55](https://github.com/JstnMcBrd/discord-delphi/pull/55))
 - Update runtime to Node.js 24 ([#58](https://github.com/JstnMcBrd/discord-delphi/pull/58), [#121](https://github.com/JstnMcBrd/discord-delphi/pull/121))
-- Use `clientReady` event instead of `ready` ([#107](https://github.com/JstnMcBrd/discord-delphi/pull/107))
+- Use `clientReady` event instead of deprecated `ready` ([#107](https://github.com/JstnMcBrd/discord-delphi/pull/107))
 - Use for-of loops instead of forEach method ([#131](https://github.com/JstnMcBrd/discord-delphi/pull/131))
 - Format error embeds as code blocks ([#139](https://github.com/JstnMcBrd/discord-delphi/pull/139))
 - Use `Events` enum for event handler names ([#145](https://github.com/JstnMcBrd/discord-delphi/pull/145))
 - Clean up README ([#164](https://github.com/JstnMcBrd/discord-delphi/pull/164))
 - Run TypeScript natively with Node.js ([#165](https://github.com/JstnMcBrd/discord-delphi/pull/165))
+- Use ephemeral flag instead of deprecated response option ([#166](https://github.com/JstnMcBrd/discord-delphi/pull/166))
 
 ### Added
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -19,7 +19,7 @@ export const help = new CommandHandler()
 		await interaction.reply({
 			embeds: [embed],
 			components: [row],
-			ephemeral: true,
+			flags: ['Ephemeral'],
 		});
 	});
 

--- a/src/commands/invite.ts
+++ b/src/commands/invite.ts
@@ -21,7 +21,7 @@ export const invite = new CommandHandler()
 		await interaction.reply({
 			...(embed && { embeds: [embed] }),
 			components: [row],
-			ephemeral: true,
+			flags: ['Ephemeral'],
 		});
 	});
 


### PR DESCRIPTION
```
(node:15516) Warning: Supplying "ephemeral" for interaction response options is deprecated. Utilize flags instead.
```