### PR TITLE
Abort on `clientReady` errors to avoid bad state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use [shields.io](https://shields.io/) for badges in README ([#32](https://github.com/JstnMcBrd/discord-delphi/pull/32))
 - Use `setInterval` instead of `setTimeout` for scheduled tasks like user activity ([#34](https://github.com/JstnMcBrd/discord-delphi/pull/34))
-- Exit with error code if commands are out-of-sync ([#36](https://github.com/JstnMcBrd/discord-delphi/pull/36))
 - Set user activity on Client initialization to fix user activity disappearing ([#36](https://github.com/JstnMcBrd/discord-delphi/pull/36))
 - Use `Object.assign` instead of `Reflect.set` ([#40](https://github.com/JstnMcBrd/discord-delphi/pull/40))
 - Use native Node.js `.env` file support instead of `dotenv` ([#42](https://github.com/JstnMcBrd/discord-delphi/pull/42))
@@ -42,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `undici` vulnerabilities ([#38](https://github.com/JstnMcBrd/discord-delphi/pull/38))
 - Fix `ws` vulnerability ([#41](https://github.com/JstnMcBrd/discord-delphi/pull/41))
+- Abort on `clientReady` errors to avoid bad state ([#167](https://github.com/JstnMcBrd/discord-delphi/pull/167))
 
 ## [2.1.0] - 2024-02-13
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,11 +1,8 @@
-import { exit } from 'node:process';
-
 import type { Client } from 'discord.js';
 
 import type { CommandHandler } from './CommandHandler.ts';
 import { help } from './help.ts';
 import { invite } from './invite.ts';
-import { error } from '../logger.ts';
 import { areCommandsInSync } from '../utils/areCommandsInSync.ts';
 
 /** The list of all command handlers. */
@@ -57,8 +54,7 @@ export async function syncCommands(client: Client<true>): Promise<void> {
 	const localCommands = Array.from(getCommandHandlers().values());
 
 	if (!areCommandsInSync(deployedCommands, localCommands)) {
-		error('Deployed commands are outdated. Please run the deployment script to update them.');
-		exit(1);
+		throw new Error('Deployed commands are outdated');
 	}
 
 	for (const command of deployedCommands) {

--- a/src/events/clientReady.ts
+++ b/src/events/clientReady.ts
@@ -1,13 +1,24 @@
+import { exit } from 'node:process';
+
 import { Events } from 'discord.js';
 
 import { EventHandler } from './EventHandler.ts';
-import { debug } from '../logger.ts';
 import { syncCommands } from '../commands/index.ts';
+import { debug, error, info } from '../logger.ts';
 
 /** Called once the client successfully logs in. */
 export const clientReady = new EventHandler(Events.ClientReady)
 	.setOnce(true)
 	.setExecution(async (client) => {
-		debug(`\tUser: ${client.user.username} (${client.user.id})`);
-		await syncCommands(client);
+		try {
+			debug(`\tUser: ${client.user.username} (${client.user.id})`);
+			await syncCommands(client);
+		}
+		catch (err) {
+			error(err);
+
+			// If the clientReady event fails, the bot is not properly initialized and must abort
+			info('Aborting...');
+			exit(1);
+		}
 	});


### PR DESCRIPTION
(This doesn't resolve any actual bugs, but instead keeps the code up-to-date with changes made in discord-cleverbot)
- https://github.com/JstnMcBrd/discord-cleverbot/pull/182